### PR TITLE
Run migrations before storing IDs in the cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,9 @@ fn app() -> Result {
     let token = std::env::var("DISCORD_TOKEN")
         .map_err(|_| "missing environment variable: DISCORD_TOKEN")?;
 
-    let _ = init_data()?;
-
     let _ = db::run_migrations()?;
+
+    let _ = init_data()?;
 
     let mut cmds = Commands::new();
 


### PR DESCRIPTION
Previously the program tried to store some IDs provided via environment
variables in the database *before* running the database migrations.
While this was fine during development it prevents migrations from being
applied to a blank database, as storing the IDs errors out.

This commit switches the startup order to first run migrations and then
store IDs in the cache.

r? @technetos